### PR TITLE
Refactor sign Method to Avoid Panic on Gas Estimation and Enhance Error Handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "ic-web3-rs"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "arrayvec 0.7.6",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-web3-rs"
-version = "0.1.9"
+version = "0.1.10"
 description = "Ethereum JSON-RPC client for IC canisters."
 homepage = "https://github.com/horizonx-tech/ic-web3"
 repository = "https://github.com/horizonx-tech/ic-web3"

--- a/src/contract/error.rs
+++ b/src/contract/error.rs
@@ -35,6 +35,17 @@ impl std::error::Error for Error {
     }
 }
 
+impl From<Error> for crate::error::Error {
+    fn from(e: Error) -> Self {
+        match e {
+            Error::InvalidOutputType(s) => crate::error::Error::InvalidResponse(s),
+            Error::Abi(eth_error) => crate::error::Error::Decoder(format!("{}", eth_error)),
+            Error::Api(api_error) => api_error,
+            Error::InterfaceUnsupported => crate::error::Error::Internal,
+        }
+    }
+}
+
 pub mod deploy {
     use crate::{error::Error as ApiError, types::H256};
     use derive_more::{Display, From};

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -420,7 +420,7 @@ mod contract_signing {
                 {
                     Ok(gas) => gas,
                     Err(e) => {
-                        return Err(e.to_string().into());
+                        return Err(e.into());
                     }
                 }
             };

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -407,18 +407,23 @@ mod contract_signing {
                 max_priority_fee_per_gas: options.max_priority_fee_per_gas,
                 ..Default::default()
             };
-            if let Some(gas) = options.gas {
-                tx.gas = gas;
+            tx.gas = if let Some(gas) = options.gas {
+                gas
             } else {
-                tx.gas = self
+                match self
                     ._estimate_gas(
                         Address::from_str(&from.to_string().as_str()).unwrap(),
                         &tx,
                         options.call_options.unwrap_or_default(),
                     )
                     .await
-                    .unwrap();
-            }
+                {
+                    Ok(gas) => gas,
+                    Err(e) => {
+                        return Err(e.to_string().into());
+                    }
+                }
+            };
             if let Some(value) = options.value {
                 tx.value = value;
             }


### PR DESCRIPTION
The sign method was refactored to eliminate unwrap() calls that could lead to panics, particularly during gas estimation. The changes ensure that errors are properly handled and reported instead of causing a crash.

